### PR TITLE
Document backend entrypoint and simplify server.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# OSU Challenge Website
+
+This repository contains both the frontend static files and the backend API.
+
+## Running the backend
+
+The backend code lives in [`osu-backend`](./osu-backend). To start the server run `node app.js` from inside that directory:
+
+```bash
+cd osu-backend
+node app.js
+```
+
+You can also run `node server.js`, which simply requires `app.js`.
+

--- a/osu-backend/server.js
+++ b/osu-backend/server.js
@@ -1,1 +1,4 @@
-const express = require('express'); const app = express(); app.listen(3000, () => console.log('🚀 API 運行中！'));
+// Entry point for starting the backend server.
+// Simply require app.js where the actual Express app and server
+// configuration live.
+require('./app');


### PR DESCRIPTION
## Summary
- point `server.js` at `app.js`
- add instructions on running the backend

## Testing
- `node -e "require('./osu-backend/server.js')" & sleep 2; kill $!`
- `node osu-backend/server.js & sleep 2; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_68403b1f44708333816041b6a66eece5