### PR TITLE
Add Jest tests for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# osu-challenge-website
+
+This repository contains a simple Node.js backend used by the website.
+
+## Running Tests
+
+1. Navigate to the backend folder:
+
+```bash
+cd osu-backend
+```
+
+2. Install dependencies:
+
+```bash
+npm install
+```
+
+3. Execute the test suite:
+
+```bash
+npm test
+```
+
+The tests are written with [Jest](https://jestjs.io/) and cover API routes such as admin login and registration creation.

--- a/osu-backend/__tests__/app.test.js
+++ b/osu-backend/__tests__/app.test.js
@@ -1,0 +1,56 @@
+const request = require('supertest');
+const fs = require('fs');
+const bcrypt = require('bcrypt');
+
+jest.mock('fs');
+jest.mock('bcrypt');
+jest.mock('../dbConnect');
+
+const getDb = require('../dbConnect');
+
+beforeEach(() => {
+  fs.readFileSync.mockReturnValue(JSON.stringify({
+    admins: [{ username: 'admin', role: 'full', passwordHash: 'hash' }]
+  }));
+  bcrypt.compare.mockResolvedValue(true);
+  getDb.mockResolvedValue({
+    collection: () => ({
+      insertOne: jest.fn().mockResolvedValue({ insertedId: '1' })
+    })
+  });
+  jest.resetModules();
+});
+
+describe('app routes', () => {
+  let app;
+  beforeEach(() => {
+    app = require('../app');
+  });
+
+  test('successful login', async () => {
+    const res = await request(app)
+      .post('/api/admin/login')
+      .send({ username: 'admin', password: 'secret' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: '登入成功', role: 'full' });
+  });
+
+  test('registration creation', async () => {
+    const agent = request.agent(app);
+    await agent.post('/api/admin/login')
+      .send({ username: 'admin', password: 'secret' });
+
+    const res = await agent.post('/api/registrations')
+      .send({
+        activityName: 'act',
+        twitchName: 'tw',
+        twitchID: '1',
+        osuID: 'osu',
+        rank: '3Digit',
+        time: '2025-01-01',
+        results: ['FC', 'FC', 'FC']
+      });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('insertedId');
+  });
+});

--- a/osu-backend/app.js
+++ b/osu-backend/app.js
@@ -305,7 +305,11 @@ app.delete('/api/registrations/:id', ensureLogin, ensureFull, async (req, res) =
 
 // 啟動伺服器
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log('Server running on port', PORT);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log('Server running on port', PORT);
+  });
+}
+
+module.exports = app;
 

--- a/osu-backend/package.json
+++ b/osu-backend/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "osu-backend",
+  "version": "1.0.0",
   "dependencies": {
     "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
@@ -6,5 +8,12 @@
     "express": "^5.1.0",
     "express-session": "^1.18.1",
     "mongodb": "^6.16.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest and supertest dev deps
- export Express app for testing
- create basic API tests
- explain how to run tests in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403b284d90833390cac7425534d1bc