### PR TITLE
Update admin fetch endpoints

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -171,12 +171,12 @@ regForm.addEventListener('submit', async (e) => {
     manualTickets: Number(document.getElementById('add-manual').value) || 0,
   };
   try {
-    const res = await fetch('https://your-api-host.com/api/admin/login', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
-    body: JSON.stringify({ username: 'HitomiCyan0820', password: 'Card1130756' })
-})
+    const res = await fetch(`${API_BASE}/api/registrations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(bodyObj)
+    });
     const data = await res.json();
     if (!res.ok) { alert(data.message || '新增失敗'); return; }
     alert('新增成功');
@@ -201,12 +201,12 @@ ncForm.addEventListener('submit', async (e) => {
   };
   if (!bodyObj.activityName) { alert('活動名稱必填'); return; }
   try {
-    const res = await fetch('https://your-api-host.com/api/admin/login', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
-    body: JSON.stringify({ username: 'HitomiCyan0820', password: 'Card1130756' })
-})
+    const res = await fetch(`${API_BASE}/api/nonchallengers`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(bodyObj)
+    });
     const data = await res.json();
     if (!res.ok) { alert(data.message || '新增失敗'); return; }
     alert('新增成功');
@@ -320,12 +320,12 @@ window.updateRow = async function(id, type) {
       manualTickets: Number(manualTickets) || 0
     };
     try {
-      const res = await fetch('https://your-api-host.com/api/admin/login', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
-    body: JSON.stringify({ username: 'HitomiCyan0820', password: 'Card1130756' })
-})
+      const res = await fetch(`${API_BASE}/api/registrations/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(bodyObj)
+      });
       const resp = await res.json();
       if (!res.ok) return alert(resp.message || '更新失敗');
       alert('更新成功');
@@ -349,12 +349,12 @@ window.updateRow = async function(id, type) {
       note,
     };
     try {
-      const res = await fetch('https://your-api-host.com/api/admin/login', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
-    body: JSON.stringify({ username: 'HitomiCyan0820', password: 'Card1130756' })
-})
+      const res = await fetch(`${API_BASE}/api/nonchallengers/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(bodyObj)
+      });
       const resp = await res.json();
       if (!res.ok) return alert(resp.message || '更新失敗');
       alert('更新成功');


### PR DESCRIPTION
## Summary
- use actual registration/nonchallenger endpoints in admin.js
- send bodyObj payloads to API_BASE

## Testing
- `npm test --prefix osu-backend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68403c470ad0833395d657a03cac234d