### PR TITLE
Add Jest tests for backend APIs

### DIFF
--- a/osu-backend/__mocks__/dbConnect.js
+++ b/osu-backend/__mocks__/dbConnect.js
@@ -1,0 +1,38 @@
+const { ObjectId } = require('mongodb');
+
+const data = {
+  registrations: [],
+  nonchallengers: []
+};
+
+function collection(name) {
+  const arr = data[name];
+  return {
+    insertOne: async (doc) => {
+      const _id = new ObjectId();
+      arr.push({ _id, ...doc });
+      return { insertedId: _id };
+    },
+    find: () => ({
+      toArray: async () => arr.slice()
+    }),
+    updateOne: async (filter, update) => {
+      const idx = arr.findIndex(d => d._id.toString() === filter._id.toString());
+      if (idx === -1) return { matchedCount: 0, modifiedCount: 0 };
+      Object.assign(arr[idx], update.$set || {});
+      return { matchedCount: 1, modifiedCount: 1 };
+    },
+    deleteOne: async (filter) => {
+      const idx = arr.findIndex(d => d._id.toString() === filter._id.toString());
+      if (idx === -1) return { deletedCount: 0 };
+      arr.splice(idx, 1);
+      return { deletedCount: 1 };
+    }
+  };
+}
+
+async function getDb() {
+  return { collection };
+}
+
+module.exports = getDb;

--- a/osu-backend/app.js
+++ b/osu-backend/app.js
@@ -303,9 +303,13 @@ app.delete('/api/registrations/:id', ensureLogin, ensureFull, async (req, res) =
   }
 });
 
-// 啟動伺服器
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log('Server running on port', PORT);
-});
+// 啟動伺服器（非測試環境才啟動）
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log('Server running on port', PORT);
+  });
+}
+
+module.exports = app;
 

--- a/osu-backend/package.json
+++ b/osu-backend/package.json
@@ -6,5 +6,12 @@
     "express": "^5.1.0",
     "express-session": "^1.18.1",
     "mongodb": "^6.16.0"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
+  },
+  "scripts": {
+    "test": "jest"
   }
 }

--- a/osu-backend/tests/api.test.js
+++ b/osu-backend/tests/api.test.js
@@ -1,0 +1,83 @@
+const request = require('supertest');
+const bcrypt = require('bcrypt');
+
+jest.mock('fs');
+const fs = require('fs');
+fs.readFileSync.mockImplementation(() => {
+  const admins = [
+    {
+      username: 'testadmin',
+      role: 'full',
+      passwordHash: bcrypt.hashSync('secret', 10)
+    }
+  ];
+  return JSON.stringify({ admins });
+});
+
+const app = require('../app');
+
+describe('API endpoints', () => {
+  let agent;
+
+  beforeEach(() => {
+    agent = request.agent(app);
+  });
+
+  test('successful login sets a session cookie', async () => {
+    const res = await agent
+      .post('/api/admin/login')
+      .send({ username: 'testadmin', password: 'secret' });
+    expect(res.status).toBe(200);
+    expect(res.headers['set-cookie']).toBeDefined();
+  });
+
+  test('unauthenticated requests receive 401', async () => {
+    const res1 = await request(app)
+      .post('/api/registrations')
+      .send({});
+    expect(res1.status).toBe(401);
+
+    const res2 = await request(app)
+      .post('/api/nonchallengers')
+      .send({});
+    expect(res2.status).toBe(401);
+  });
+
+  test('creating a registration returns expected status and fields', async () => {
+    await agent
+      .post('/api/admin/login')
+      .send({ username: 'testadmin', password: 'secret' });
+
+    const body = {
+      activityName: 'test',
+      twitchName: 'abc',
+      twitchID: '123',
+      osuID: 'osu1',
+      rank: '5Digit',
+      time: '2023-01-01',
+      results: ['挑戰失敗', '挑戰失敗', '挑戰失敗'],
+      manualTickets: 1
+    };
+    const res = await agent.post('/api/registrations').send(body);
+    expect(res.status).toBe(200);
+    expect(res.body.insertedId).toBeDefined();
+    expect(res.body.message).toBeDefined();
+  });
+
+  test('creating a nonchallenger returns expected status and fields', async () => {
+    await agent
+      .post('/api/admin/login')
+      .send({ username: 'testadmin', password: 'secret' });
+
+    const body = {
+      activityName: 'test',
+      twitchName: 'abc',
+      twitchID: '123',
+      manualTickets: 2
+    };
+    const res = await agent.post('/api/nonchallengers').send(body);
+    expect(res.status).toBe(200);
+    expect(res.body.insertedId).toBeDefined();
+    expect(res.body.message).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- export Express app for testing
- add Jest and Supertest configuration
- mock database connector
- provide API tests for login and creation routes

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403c4a81748333aab35d3d3f9ee867