### PR TITLE
Add registration sync script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# osu-challenge-website
+
+This repository contains the static files for the osu! challenge website.
+
+## Updating registration data
+
+The `scripts/update_registrations.py` script pulls the latest entries from the
+Google Form's linked Google Sheet and writes them to `data/registrations.json`.
+This keeps the website data in sync with form responses.
+
+### Prerequisites
+
+- Python 3.7 or later
+- [`gspread`](https://pypi.org/project/gspread/) library
+- A Google service account JSON credentials file
+- Access to the Google Sheet containing the form responses
+
+Install the Python dependency:
+
+```bash
+pip install gspread
+```
+
+### Running the update script
+
+Set the following environment variables:
+
+- `SHEET_ID` – ID of the Google Sheet
+- `GOOGLE_APPLICATION_CREDENTIALS` – path to the service account credentials
+  (defaults to `service_account.json` in the repository root)
+- `WORKSHEET` – optional worksheet name (defaults to `Sheet1`)
+
+Then run:
+
+```bash
+python scripts/update_registrations.py
+```
+
+The script will fetch all rows from the sheet, map the columns to the expected
+fields (`twitchName`, `twitchID`, `activityName`, `rank`, `time`, `identity`,
+`results`), and write the output to `data/registrations.json` using UTF-8
+encoding.

--- a/scripts/update_registrations.py
+++ b/scripts/update_registrations.py
@@ -1,0 +1,56 @@
+import os
+import json
+from typing import List
+
+try:
+    import gspread  # type: ignore
+except ImportError as e:
+    raise SystemExit("gspread must be installed: pip install gspread") from e
+
+
+COLUMN_MAPPING = {
+    "Twitch Name": "twitchName",
+    "Twitch ID": "twitchID",
+    "Activity Name": "activityName",
+    "Rank": "rank",
+    "Time": "time",
+    "Identity": "identity",
+    "Results": "results",
+}
+
+
+def fetch_rows(sheet_id: str, worksheet: str = "Sheet1", creds: str = "service_account.json") -> List[dict]:
+    gc = gspread.service_account(filename=creds)
+    sh = gc.open_by_key(sheet_id)
+    ws = sh.worksheet(worksheet)
+    return ws.get_all_records()
+
+
+def transform_row(row: dict) -> dict:
+    result = {}
+    for col, field in COLUMN_MAPPING.items():
+        value = row.get(col, "")
+        if field == "results":
+            if isinstance(value, str):
+                value = [v.strip() for v in value.split(',') if v.strip()]
+        result[field] = value
+    return result
+
+
+def main():
+    sheet_id = os.environ.get("SHEET_ID") or "<your-sheet-id>"
+    worksheet = os.environ.get("WORKSHEET", "Sheet1")
+    creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "service_account.json")
+
+    rows = fetch_rows(sheet_id, worksheet, creds)
+    transformed = [transform_row(row) for row in rows]
+
+    out_file = os.path.join(os.path.dirname(__file__), '..', 'data', 'registrations.json')
+    out_file = os.path.abspath(out_file)
+    with open(out_file, 'w', encoding='utf-8') as f:
+        json.dump(transformed, f, ensure_ascii=False, indent=2)
+    print(f"Wrote {len(transformed)} registrations to {out_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `update_registrations.py` to fetch Google Sheet responses
- document how to run the script in README

## Testing
- `python -m py_compile scripts/update_registrations.py`

------
https://chatgpt.com/codex/tasks/task_e_6840613028c0833388dfdd94731ed992