### PR TITLE
Add Windows example for update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,17 @@ Set the following environment variables:
   (defaults to `service_account.json` in the repository root)
 - `WORKSHEET` – optional worksheet name (defaults to `Sheet1`)
 
-Then run:
+Then run the script from the repository root so the path resolves correctly:
 
 ```bash
+python scripts/update_registrations.py
+```
+
+On Windows using PowerShell the equivalent commands are:
+
+```powershell
+$env:SHEET_ID = 'your-sheet-id'
+$env:GOOGLE_APPLICATION_CREDENTIALS = 'C:\path\service_account.json'
 python scripts/update_registrations.py
 ```
 


### PR DESCRIPTION
## Summary
- show how to run the registration update script from Windows PowerShell
- note the script should be run from the repository root

## Testing
- `python -m py_compile scripts/update_registrations.py`

------
https://chatgpt.com/codex/tasks/task_e_68409b90120c8333aa449e2ea6d1a4fa